### PR TITLE
update nn-c721dfca8cd3.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -40,7 +40,7 @@ Value evaluate(const Position& pos);
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro, as it is used in the Makefile.
-// #define EvalFileDefaultNameBig "nn-ae6a388e4a1a.nnue"
+// #define EvalFileDefaultNameBig "nn-c721dfca8cd3.nnue"
 // #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
Update default main net to nn-c721dfca8cd3.nnue
Created by first retraining the spsa-tuned main net `nn-ae6a388e4a1a.nnue` with:
- using v6-dd data without bestmove captures removed
- addition of T80 mar2024 data
- increasing loss by 20% when Q is too high
- torch.compile changes for marginal training speed gains
linrock authored


Passed STC Regression:
https://hypnos.bigzerchess.com/test/431/
Elo   | 2.26 +- 1.28 (95%)
Conf  | 10.0+0.10s Threads=1 Hash=16MB
Games | N: 40078 W: 3627 L: 3366 D: 33085
Penta | [65, 2449, 14769, 2672, 84]

Passed LTC Regression:
https://hypnos.bigzerchess.com/test/432/
Elo   | 0.61 +- 0.74 (95%)
Conf  | 60.0+0.60s Threads=1 Hash=64MB
Games | N: 40000 W: 1416 L: 1346 D: 37238
Penta | [4, 884, 18154, 954, 4]

(bench: 1654143)
