### PR TITLE
Introduce and adapt pre-qsearch ttmove extensions into pv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1498,6 +1498,10 @@ moves_loop:  // When in check, search starts here
             (ss + 1)->pv    = pv;
             (ss + 1)->pv[0] = MOVE_NONE;
 
+            // Extend move from transposition table if we are about to dive into qsearch.
+            if (move == ttMove && ss->ply <= thisThread->rootDepth * 2)
+                newDepth = std::max(newDepth, 1);
+
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);
         }
 


### PR DESCRIPTION
Original code
The idea is that we are about to dive into qsearch (next search depth is <= 0) but since we have the move in transposition table we should extend that move and evaluate it with more precise search - because branch seems important.

Vizvezdenec authored