### PR TITLE
NNUE Shashin dynamic blend + SEE gating + ProbCut calm filter; search…

### DIFF
--- a/src/build-all.bat
+++ b/src/build-all.bat
@@ -1,0 +1,55 @@
+@echo off
+setlocal
+
+set BIN=bin
+if not exist %BIN% mkdir %BIN%
+
+rem === AVX2 ===
+echo ▶ Compilo AVX2...
+mingw32-make clean >nul 2>&1
+mingw32-make profile-build ARCH=x86-64-avx2 COMP=mingw -j 12
+if exist hypnos.exe (
+    move /Y hypnos.exe %BIN%\hypnos-avx2.exe >nul
+    echo ✔ hypnos-avx2.exe creato
+) else (
+    echo ✘ Errore build AVX2
+)
+
+rem === BMI2 ===
+echo ▶ Compilo BMI2...
+mingw32-make clean >nul 2>&1
+mingw32-make profile-build ARCH=x86-64-bmi2 COMP=mingw -j 12
+if exist hypnos.exe (
+    move /Y hypnos.exe %BIN%\hypnos-bmi2.exe >nul
+    echo ✔ hypnos-bmi2.exe creato
+) else (
+    echo ✘ Errore build BMI2
+)
+
+rem === SSE41 + POPCNT ===
+echo ▶ Compilo SSE41-POPCNT...
+mingw32-make clean >nul 2>&1
+mingw32-make profile-build ARCH=x86-64-sse41-popcnt COMP=mingw -j 12
+if exist hypnos.exe (
+    move /Y hypnos.exe %BIN%\hypnos-sse41.exe >nul
+    echo ✔ hypnos-sse41.exe creato
+) else (
+    echo ✘ Errore build SSE41
+)
+
+rem === GENERIC ===
+echo ▶ Compilo GENERIC...
+mingw32-make clean >nul 2>&1
+mingw32-make profile-build ARCH=x86-64 COMP=mingw -j 12
+if exist hypnos.exe (
+    move /Y hypnos.exe %BIN%\hypnos-generic.exe >nul
+    echo ✔ hypnos-generic.exe creato
+) else (
+    echo ✘ Errore build GENERIC
+)
+
+echo.
+echo Tutte le build completate. Gli eseguibili si trovano in %BIN%\
+echo.
+pause
+endlocal

--- a/src/build-all.ps1
+++ b/src/build-all.ps1
@@ -1,0 +1,33 @@
+# build-all.ps1
+# Compila HypnoS in 4 varianti e salva gli eseguibili in .\bin\
+
+$arches = @{
+    "avx2"    = "x86-64-avx2"
+    "bmi2"    = "x86-64-bmi2"
+    "sse41"   = "x86-64-sse41-popcnt"
+    "generic" = "x86-64"
+}
+
+$binDir = Join-Path $PSScriptRoot "bin"
+if (-not (Test-Path $binDir)) {
+    New-Item -ItemType Directory -Path $binDir | Out-Null
+}
+
+foreach ($name in $arches.Keys) {
+    $arch = $arches[$name]
+
+    Write-Host "▶ Compilo variante $name ($arch)..." -ForegroundColor Cyan
+    mingw32-make clean 2>$null | Out-Null
+    mingw32-make profile-build ARCH=$arch COMP=mingw -j 12
+
+    $exe = Join-Path $PSScriptRoot "hypnos.exe"
+    if (Test-Path $exe) {
+        $target = Join-Path $binDir ("hypnos-" + $name + ".exe")
+        Move-Item -Force $exe $target
+        Write-Host "✔ Creato $target" -ForegroundColor Green
+    } else {
+        Write-Host "✘ Nessun exe trovato per $name" -ForegroundColor Red
+    }
+}
+
+Write-Host "Tutte le build completate. Gli eseguibili sono in $binDir" -ForegroundColor Yellow

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -254,16 +254,24 @@ int compute_material_imbalance(const Position& pos) {
 }
 
 int compute_center_control(const Position& pos) {
-    // Evaluate control over central squares.
+    // Measure control over the four central squares (D4, E4, D5, E5)
+    // using ATTACKERS rather than mere occupancy. Positive values favor White,
+    // negative values favor Black. This produces a signal that correlates
+    // with initiative and piece activity in the center, which is what Shashin wants.
     Square centralSquares[] = { SQ_D4, SQ_E4, SQ_D5, SQ_E5 };
     int control = 0;
 
     for (Square sq : centralSquares) {
-        // Increment control if a piece occupies the square.
-        if (pos.piece_on(sq) != NO_PIECE) {
-            control++;
-        }
+        // Count white and black attackers to the square.
+        // We intersect the attackers bitboard with each side's pieces;
+        // this is consistent with other helpers in your codebase.
+        const int w = popcount(pos.attackers_to(sq) & pos.pieces(WHITE));
+        const int b = popcount(pos.attackers_to(sq) & pos.pieces(BLACK));
+
+        // Net control contribution for this square.
+        control += (w - b);
     }
+
     return control;
 }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -117,39 +117,173 @@ void init(OptionsMap& o) {
     o["UCI_LimitStrength"] << Option(false);
     o["UCI_Elo"] << Option(1320, 1320, 3190);
     o["UCI_ShowWDL"] << Option(false);
-    o["Book File"] << Option("<empty>", on_book);
-    o["Book Width"] << Option(1, 1, 20);
-    o["Book Depth"] << Option(255, 1, 255);
-    o["SyzygyPath"] << Option("<empty>", on_tb_path);
-    o["SyzygyProbeDepth"] << Option(1, 1, 100);
-    o["Syzygy50MoveRule"] << Option(true);
-    o["SyzygyProbeLimit"] << Option(7, 0, 7);
-    o["Experience Enabled"] << Option(false, on_exp_enabled);
-    o["Experience File"] << Option("Hypnos.exp", on_exp_file);
-    o["Experience Readonly"] << Option(false);
-    o["Experience Book"] << Option(false);
-    o["Experience Book Width"] << Option(1, 1, 20);
-    o["Experience Book Eval Importance"] << Option(5, 0, 10);
-    o["Experience Book Min Depth"] << Option(27, Experience::MinDepth, 64);
-    o["Experience Book Max Moves"] << Option(16, 1, 100);
-    o["EvalFile"] << Option(EvalFileDefaultNameBig, on_eval_file);
-    o["EvalFileSmall"] << Option(EvalFileDefaultNameSmall, on_eval_file);
-    o["Variety"] << Option(0, 0, 40);
-    o["Variety Max Score"] << Option(0, 0, 50);
-    o["Variety Max Moves"] << Option(0, 0, 40);    // Manual Weight Adjustment Option
-    o["NNUE ManualWeights"] << Option(false, [](const Option& opt) {
-    // Check if Manual Weights option is enabled or disabled.
-     if (opt) {
-        sync_cout << "info string NNUE ManualWeights enabled. Using user-defined weights." << sync_endl;
-    } else {
-        sync_cout << "info string NNUE ManualWeights disabled. Using dynamic weights." << sync_endl;
-    }
-});
+    o["Book File"] 
+        << Option("<empty>", [](const Option& opt) {
+            on_book(opt);
+            sync_cout << "info string Book File = " << (std::string)opt << sync_endl;
+        });
 
-    o["NNUE StrategyMaterialWeight"] 
-        << Option(0, -12, 12, on_strategy_material_weight); // Material weight adjustment.
-    o["NNUE StrategyPositionalWeight"] 
-        << Option(0, -12, 12, on_strategy_positional_weight); // Positional weight adjustment.
+    o["Book Width"] 
+        << Option(1, 1, 20, [](const Option& opt) {
+            sync_cout << "info string Book Width = " << int(opt) << sync_endl;
+        });
+
+    o["Book Depth"] 
+        << Option(255, 1, 255, [](const Option& opt) {
+            sync_cout << "info string Book Depth = " << int(opt) << sync_endl;
+        });
+
+    o["SyzygyPath"] 
+        << Option("<empty>", [](const Option& opt) {
+            on_tb_path(opt);
+            sync_cout << "info string SyzygyPath = " << (std::string)opt << sync_endl;
+        });
+
+    o["SyzygyProbeDepth"] 
+        << Option(1, 1, 100, [](const Option& opt) {
+            sync_cout << "info string SyzygyProbeDepth = " << int(opt) << sync_endl;
+        });
+
+    o["Syzygy50MoveRule"] 
+        << Option(true, [](const Option& opt) {
+            sync_cout << "info string Syzygy50MoveRule is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        });
+
+    o["SyzygyProbeLimit"] 
+        << Option(7, 0, 7, [](const Option& opt) {
+            sync_cout << "info string SyzygyProbeLimit = " << int(opt) << " men" << sync_endl;
+        });
+
+    o["Experience Enabled"] 
+        << Option(false, [](const Option& opt) {
+            on_exp_enabled(opt);
+            sync_cout << "info string Experience Enabled is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        });
+
+    o["Experience File"] 
+        << Option("Hypnos.exp", [](const Option& opt) {
+            on_exp_file(opt);
+            sync_cout << "info string Experience File = " << (std::string)opt << sync_endl;
+        });
+
+    o["Experience Readonly"] 
+        << Option(false, [](const Option& opt) {
+            sync_cout << "info string Experience Readonly is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        });
+
+    o["Experience Book"] 
+        << Option(false, [](const Option& opt) {
+            sync_cout << "info string Experience Book is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        });
+
+    o["Experience Book Width"] 
+        << Option(1, 1, 20, [](const Option& opt) {
+            sync_cout << "info string Experience Book Width = " << int(opt) << sync_endl;
+        });
+
+    o["Experience Book Eval Importance"] 
+        << Option(5, 0, 10, [](const Option& opt) {
+            sync_cout << "info string Experience Book Eval Importance = " << int(opt) << sync_endl;
+        });
+
+    o["Experience Book Min Depth"] 
+        << Option(27, Experience::MinDepth, 64, [](const Option& opt) {
+            sync_cout << "info string Experience Book Min Depth = " << int(opt) << sync_endl;
+        });
+
+    o["Experience Book Max Moves"] 
+        << Option(16, 1, 100, [](const Option& opt) {
+            sync_cout << "info string Experience Book Max Moves = " << int(opt) << sync_endl;
+        });
+
+    o["EvalFile"] 
+        << Option(EvalFileDefaultNameBig, [](const Option& opt) {
+            on_eval_file(opt);
+            sync_cout << "info string EvalFile = " << (std::string)opt << sync_endl;
+        });
+
+    o["EvalFileSmall"] 
+        << Option(EvalFileDefaultNameSmall, [](const Option& opt) {
+            on_eval_file(opt);
+            sync_cout << "info string EvalFileSmall = " << (std::string)opt << sync_endl;
+        });
+
+    o["Variety"] 
+        << Option(0, 0, 40, [](const Option& opt) {
+            sync_cout << "info string Variety = " << int(opt) << sync_endl;
+        });
+
+    o["Variety Max Score"] 
+        << Option(0, 0, 50, [](const Option& opt) {
+            sync_cout << "info string Variety Max Score = " << int(opt) << sync_endl;
+        });
+
+    o["Variety Max Moves"] 
+        << Option(0, 0, 40, [](const Option& opt) {
+            sync_cout << "info string Variety Max Moves = " << int(opt) << sync_endl;
+        });
+
+    o["NNUE Dynamic Weights"]
+        << Option(true, [](const Option& opt) {
+            sync_cout << "info string NNUE Dynamic Weights is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        }); // Enable dynamic Shashin-style weights (phase/indicators blend).
+
+    o["NNUE ManualWeights"] << Option(false, [](const Option& opt) {
+        // Check if Manual Weights option is enabled or disabled.
+        if (opt) {
+            sync_cout << "info string NNUE ManualWeights enabled. Using user-defined weights." << sync_endl;
+        } else {
+            sync_cout << "info string NNUE ManualWeights disabled. Using dynamic weights." << sync_endl;
+        }
+    });
+
+    // --- NNUE strategy manual knobs --------------------------------------------
+o["NNUE StrategyMaterialWeight"]
+    << Option(0, -12, 12, [](const Option& opt) {
+        on_strategy_material_weight(opt);
+        const int v = (int)opt;
+        sync_cout << "info string NNUE StrategyMaterialWeight = " << v << sync_endl;
+    });
+
+o["NNUE StrategyPositionalWeight"]
+    << Option(0, -12, 12, [](const Option& opt) {
+        on_strategy_positional_weight(opt);
+        const int v = (int)opt;
+        sync_cout << "info string NNUE StrategyPositionalWeight = " << v << sync_endl;
+    });
+
+    // --- Search hygiene toggles -------------------------------------------------
+    o["SEE Gating Quiet"] 
+        << Option(true, [](const Option& opt) {
+            sync_cout << "info string SEE Gating Quiet is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        }); // Enable SEE gating on quiet moves.
+
+    o["SEE Gating Quiet MoveCount"] 
+        << Option(12, 0, 200, [](const Option& opt) {
+            sync_cout << "info string SEE Gating Quiet MoveCount = " << int(opt) << sync_endl;
+        }); // Apply gating only after N moves in the node.
+
+    o["SEE Threshold Quiet"] 
+        << Option(0, -1000, 1000, [](const Option& opt) {
+            sync_cout << "info string SEE Threshold Quiet = " << int(opt) << " cp" << sync_endl;
+        }); // SEE threshold (centipawns) for quiets.
+
+    o["ProbCut Calm Filter"] 
+        << Option(true, [](const Option& opt) {
+            sync_cout << "info string ProbCut Calm Filter is now: "
+                      << (opt ? "enabled" : "disabled") << sync_endl;
+        }); // Skip ProbCut if the position looks sharp.
+
+    o["ProbCut Attackers Threshold"] 
+        << Option(3, 0, 16, [](const Option& opt) {
+            sync_cout << "info string ProbCut Attackers Threshold = " << int(opt) << sync_endl;
+        }); // Max attackers on either king to still allow ProbCut.
 
     o["Use Exploration Factor"] << Option(false, [](const Option& opt) {
         sync_cout << "info string Use Exploration Factor is now: "


### PR DESCRIPTION
… hygiene & bugfixes

Implement Shashin-style dynamic blending of NNUE strategy weights (Tal / Petrosian / Capablanca) driven by phase + positional indicators, with a light tactical-complexity cue (checks, king-ring pressure, tension/hanging pieces). Weights are clamped, normalized to 100, per-thread cached, and respect NNUE ManualWeights when enabled.

Add UCI options:

NNUE ManualWeights (bool): honor user material/positional knobs (logs enable/disable).

NNUE Dynamic Weights (bool, default ON): enable phase/indicator blending.

NNUE StrategyMaterialWeight, NNUE StrategyPositionalWeight: user deltas (-12..+12).

SEE Gating Quiet (bool, default ON), SEE Gating Quiet MoveCount (int, default 12), SEE Threshold Quiet (cp, default 0).

ProbCut Calm Filter (bool, default ON), ProbCut Attackers Threshold (int, default 3).

Search hygiene / fixes

Rework reduction(...) with style-aware scaling, sane clamps, safe division.

Fix braces/indentation in iterative deepening & root bookkeeping (remove misleading-indentation warning).

Clean up update_exploration_factor(...) (dedup commits, clamp, light king-pressure cue).

ProbCut: optional calm-position gate based on king-ring attackers.

Quiet-move SEE gating inserted in the move loop (kept user indentation).

evaluate_nnue.cpp hardening

Use Hypnos::Options (not Hypnos::UCI::Options), remove stray scopes after function end, correct pop_lsb(oppPieces) usage, close namespaces correctly, and unify the blend function.